### PR TITLE
Update action for use with projectV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ The Action is largely feature complete with regards to its initial goals. Find a
 * `item_title` - The title of the issue or pull request
 * `option_id` - The global ID of the selected option
 * `project_id` - The global ID of the project
+
+### V1 vs V2
+
+In June 2022, [GitHub announced a breaking change to the Projects API](https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/). As such, the `@v1` tag of this action will cease working on October 1st, 2022.  You can upgrade to the `@v2` tag (by updating the reference in your Workflow file) at any time. Text and single selection fields will not require any additional changes. Date, Number, and Iteration fields will require you to supply a `value_type`, when using `v2` of this Action.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The Action is largely feature complete with regards to its initial goals. Find a
 * `organization` - The organization that contains the project, defaults to the current repository owner
 * `project_number` - The project number from the project's URL
 * `value` - The value to set the project field to
+* `value_type` - The type of value to update (text, date, number, iterationId, or singleSectionOptionId). Auto-detected for "text" and "single select" fields. Required for all other field types. See https://docs.github.com/en/graphql/reference/input-objects#projectv2fieldvalue.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update status
-        uses: benbalter/update-project-action@v1
+        uses: benbalter/update-project-action@v2
         with:
           github_token: ${{ secrets.STATUS_UPDATE_TOKEN }}
           organization: github

--- a/README.md
+++ b/README.md
@@ -51,12 +51,10 @@ The Action is largely feature complete with regards to its initial goals. Find a
 * `organization` - The organization that contains the project, defaults to the current repository owner
 * `project_number` - The project number from the project's URL
 * `value` - The value to set the project field to
-* `value_type` - The type of value to update (text, date, number, iterationId, or singleSectionOptionId). Auto-detected for "text" and "single select" fields. Required for all other field types. See https://docs.github.com/en/graphql/reference/input-objects#projectv2fieldvalue.
-
 ### Outputs
 
 * `field_id` - The global ID of the field
-* `field_is_select` - Whether or not the field is a select field vs. free-form input
+* `field_type` - The updated field's ProjectV2FieldType (text, single_select, number, date, or iteration)
 * `item_id` - The global ID of the issue or pull request
 * `item_title` - The title of the issue or pull request
 * `option_id` - The global ID of the selected option
@@ -64,4 +62,4 @@ The Action is largely feature complete with regards to its initial goals. Find a
 
 ### V1 vs V2
 
-In June 2022, [GitHub announced a breaking change to the Projects API](https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/). As such, the `@v1` tag of this action will cease working on October 1st, 2022.  You can upgrade to the `@v2` tag (by updating the reference in your Workflow file) at any time. Text and single selection fields will not require any additional changes. Date, Number, and Iteration fields will require you to supply a `value_type`, when using `v2` of this Action.
+In June 2022, [GitHub announced a breaking change to the Projects API](https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/). As such, the `@v1` tag of this action will cease working on October 1st, 2022.  You can upgrade to the `@v2` tag (by updating the reference in your Workflow file) at any time.

--- a/action.yml
+++ b/action.yml
@@ -154,9 +154,9 @@ runs:
           echo "::set-output name=value_to_set::$VALUE"
           echo '::set-output name=value_type::'${{ inputs.value_type }}
 
-          if [ "${{ inputs.value_type }}" = "date" ]
+          if [ "${{ inputs.value_type }}" = "date" ]; then
             echo '::set-output name=value_graphql_type::Date'
-          elif [ "${{ inputs.value_type }}" = "number" ]
+          elif [ "${{ inputs.value_type }}" = "number" ]; then
             echo '::set-output name=value_graphql_type::Float'
           else
             echo '::set-output name=value_graphql_type::String'

--- a/action.yml
+++ b/action.yml
@@ -133,7 +133,7 @@ runs:
         if [ -z "$ITEM_ID" ]; then echo "Item not found with ID '$CONTENT_ID'"; exit 1; fi
         if [ -z "$FIELD_ID" ]; then echo "Field '$FIELD' not found"; exit 1; fi
         if [[ "$FIELD_TYPE" = "single_select" && -z "$OPTION_ID" ]]; then echo "Option not found with value '$VALUE'"; exit 1; fi
-    
+
     - name: Parse value
       shell: bash
       id: parse_value

--- a/action.yml
+++ b/action.yml
@@ -111,7 +111,7 @@ runs:
           echo '::set-output name=item_id::'$(jq -r '.data.organization.projectV2.items.nodes[] | select(.content.id==$CONTENT_ID) | .id' "$FILE_NAME" --arg CONTENT_ID "$CONTENT_ID")
           echo '::set-output name=item_title::'$(jq -r '.data.organization.projectV2.items.nodes[] | select(.content.id==$CONTENT_ID) | .content.title' "$FILE_NAME" --arg CONTENT_ID "$CONTENT_ID")
           echo '::set-output name=field_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' "$FILE_NAME" --arg FIELD "$FIELD")
-          echo '::set-output name=field_type::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType |= ascii_downcase' "$FILE_NAME" --arg FIELD "$FIELD")
+          echo '::set-output name=field_type::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType | ascii_downcase' "$FILE_NAME" --arg FIELD "$FIELD")
           echo '::set-output name=option_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name | contains($VALUE)) | .id' "$FILE_NAME" --arg VALUE "$VALUE" --arg FIELD "$FIELD")
 
     - name: Ensure project, item, field, and option were found

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: A GitHub Token with access to both the source issue and the destination project (`repo` and `write:org` scopes)
     required: true
   value_type:
-    description: The type of value to update (text, date, number, iterationId, or singleSectionOptionId). See https://docs.github.com/en/graphql/reference/input-objects#projectv2fieldvalue.
+    description: The type of value to update (text, date, number, iterationId, or singleSectionOptionId). Auto-detected for "text" and "single select" fields. Required for all other field types. See https://docs.github.com/en/graphql/reference/input-objects#projectv2fieldvalue.
     required: false
     default: text
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
       run: |
         # Fetch project metadata
         if [ ! -f "$FILE_NAME" ]; then
-          gh api graphql -f query="$QUERY" -F project_number=$PROJECT_NUMBER -f organization=$ORGANIZATION > "$FILE_NAME"
+          gh api graphql -f query="$QUERY" -F project_number=$PROJECT_NUMBER -F organization=$ORGANIZATION > "$FILE_NAME"
         else
           echo "Using cached project metadata from '$FILE_NAME'"
         fi
@@ -169,7 +169,7 @@ runs:
           export VALUE_TO_SET="$(jq -r '{"text": $VALUE}' -n '{}' --arg VALUE "$VALUE")"
         fi
 
-        gh api graphql -f query="$QUERY" -f project=$PROJECT_ID -f item=$ITEM_ID -f field=$FIELD_ID -f value="$VALUE_TO_SET"
+        gh api graphql -f query="$QUERY" -F project=$PROJECT_ID -F item=$ITEM_ID -F field=$FIELD_ID -F value="$VALUE_TO_SET"
 
         echo ""
         echo "Updated field '$FIELD' on '$ITEM_TITLE' to '$VALUE'. Happy reporting! 📈"

--- a/action.yml
+++ b/action.yml
@@ -52,36 +52,44 @@ runs:
         CONTENT_ID: ${{ inputs.content_id }}
         VALUE: ${{ inputs.value }}
         FILE_NAME: project-${{ inputs.organization }}-${{ inputs.project_number }}.json
-      shell: bash
-      run: |
-        # Fetch project metadata
-        if [ ! -f "$FILE_NAME" ]; then
-          gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
-            query($organization: String!, $project_number: Int!) {
-              organization(login: $organization) {
-                projectNext(number: $project_number) {
-                  id
-                  items(first: 100) {
-                    nodes {
-                      id
-                      content {
-                        ... on Issue {
-                          id
-                          title
-                        }
+        QUERY: |
+          query ($organization: String!, $project_number: Int!) {
+            organization(login: $organization) {
+              projectV2(number: $project_number) {
+                id
+                items(first: 100) {
+                  nodes {
+                    id
+                    content {
+                      ... on Issue {
+                        id
+                        title
                       }
                     }
                   }
-                  fields(first: 25) {
-                    nodes {
+                }
+                fields(first: 25) {
+                  nodes {
+                    ... on ProjectV2FieldCommon {
                       id
                       name
-                      settings
+                    }
+                    ... on ProjectV2SingleSelectField {
+                      options {
+                        id
+                        name
+                      }
                     }
                   }
                 }
               }
-            }' -F project_number=$PROJECT_NUMBER -f organization=$ORGANIZATION > "$FILE_NAME"
+            }
+          }
+      shell: bash
+      run: |
+        # Fetch project metadata
+        if [ ! -f "$FILE_NAME" ]; then
+          gh api graphql -f query="$QUERY" -F project_number=$PROJECT_NUMBER -f organization=$ORGANIZATION > "$FILE_NAME"
         else
           echo "Using cached project metadata from '$FILE_NAME'"
         fi
@@ -138,7 +146,7 @@ runs:
         ITEM_TITLE: ${{ steps.parse_project_metadata.outputs.item_title }}
         QUERY: |
           mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
-            updateProjectNextItemField(
+            updateProjectV2ItemFieldValue(
               input: {
                 projectId: $project
                 itemId: $item
@@ -146,7 +154,7 @@ runs:
                 value: $value
               }
             ) {
-              projectNextItem {
+              projectV2Item {
                 id
               }
             }
@@ -161,7 +169,7 @@ runs:
           export VALUE_TO_SET="$VALUE"
         fi
 
-        gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query="$QUERY" -f project=$PROJECT_ID -f item=$ITEM_ID -f field=$FIELD_ID -f value="$VALUE_TO_SET"
+        gh api graphql -f query="$QUERY" -f project=$PROJECT_ID -f item=$ITEM_ID -f field=$FIELD_ID -f value="$VALUE_TO_SET"
 
         echo ""
         echo "Updated field '$FIELD' on '$ITEM_TITLE' to '$VALUE'. Happy reporting! 📈"

--- a/action.yml
+++ b/action.yml
@@ -159,6 +159,7 @@ runs:
         FIELD_ID: ${{ steps.parse_project_metadata.outputs.field_id }}
         ITEM_TITLE: ${{ steps.parse_project_metadata.outputs.item_title }}
         VALUE_TO_SET: ${{ steps.parse_field_type.outputs.value_to_set }}
+        VALUE: ${{ inputs.value }}
         QUERY: |
           mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
             updateProjectV2ItemFieldValue(

--- a/action.yml
+++ b/action.yml
@@ -106,12 +106,12 @@ runs:
         FILE_NAME: ${{ steps.fetch_project_metadata.outputs.file_name }}
       run: |
           # Parse project metadata
-          echo '::set-output name=project_id::'$(jq -r '.data.organization.projectNext.id' "$FILE_NAME")
-          echo '::set-output name=item_id::'$(jq -r '.data.organization.projectNext.items.nodes[] | select(.content.id==$CONTENT_ID) | .id' "$FILE_NAME" --arg CONTENT_ID "$CONTENT_ID")
-          echo '::set-output name=item_title::'$(jq -r '.data.organization.projectNext.items.nodes[] | select(.content.id==$CONTENT_ID) | .content.title' "$FILE_NAME" --arg CONTENT_ID "$CONTENT_ID")
-          echo '::set-output name=field_id::'$(jq -r '.data.organization.projectNext.fields.nodes[] | select(.name==$FIELD) | .id' "$FILE_NAME" --arg FIELD "$FIELD")
-          echo '::set-output name=field_is_select::'$(jq -r '.data.organization.projectNext.fields.nodes[] | select(.name==$FIELD) | .settings | fromjson | has("options")' "$FILE_NAME" --arg FIELD "$FIELD")
-          echo '::set-output name=option_id::'$(jq -r '.data.organization.projectNext.fields.nodes[] | select(.name==$FIELD) | .settings | fromjson | .options[]? | select(.name | contains($VALUE)) | .id' "$FILE_NAME" --arg VALUE "$VALUE" --arg FIELD "$FIELD")
+          echo '::set-output name=project_id::'$(jq -r '.data.organization.projectV2.id' "$FILE_NAME")
+          echo '::set-output name=item_id::'$(jq -r '.data.organization.projectV2.items.nodes[] | select(.content.id==$CONTENT_ID) | .id' "$FILE_NAME" --arg CONTENT_ID "$CONTENT_ID")
+          echo '::set-output name=item_title::'$(jq -r '.data.organization.projectV2.items.nodes[] | select(.content.id==$CONTENT_ID) | .content.title' "$FILE_NAME" --arg CONTENT_ID "$CONTENT_ID")
+          echo '::set-output name=field_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' "$FILE_NAME" --arg FIELD "$FIELD")
+          echo '::set-output name=field_is_select::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .settings | fromjson | has("options")' "$FILE_NAME" --arg FIELD "$FIELD")
+          echo '::set-output name=option_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .settings | fromjson | .options[]? | select(.name | contains($VALUE)) | .id' "$FILE_NAME" --arg VALUE "$VALUE" --arg FIELD "$FIELD")
 
     - name: Ensure project, item, field, and option were found
       env:

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,6 @@ inputs:
   github_token:
     description: A GitHub Token with access to both the source issue and the destination project (`repo` and `write:org` scopes)
     required: true
-  value_type:
-    description: The type of value to update (text, date, number, iterationId, or singleSectionOptionId). Auto-detected for "text" and "single select" fields. Required for all other field types. See https://docs.github.com/en/graphql/reference/input-objects#projectv2fieldvalue.
-    required: false
-    default: text
 outputs:
   project_id:
     description: "The global ID of the project"
@@ -37,9 +33,9 @@ outputs:
   field_id:
     description: "The global ID of the field"
     value: ${{ steps.parse_project_metadata.outputs.field_id }}
-  field_is_select:
-    description: "Whether or not the field is a select field vs. free-form input"
-    value: ${{ steps.parse_project_metadata.outputs.field_is_select }}
+  field_type:
+    description: "The updated field's ProjectV2FieldType (text, single_select, number, date, or iteration)"
+    value: ${{ steps.parse_project_metadata.outputs.field_type }}
   option_id:
     description: "The global ID of the selected option"
     value: ${{ steps.parse_project_metadata.outputs.option_id }}
@@ -77,6 +73,7 @@ runs:
                     ... on ProjectV2FieldCommon {
                       id
                       name
+                      dataType
                     }
                     ... on ProjectV2SingleSelectField {
                       options {
@@ -114,7 +111,7 @@ runs:
           echo '::set-output name=item_id::'$(jq -r '.data.organization.projectV2.items.nodes[] | select(.content.id==$CONTENT_ID) | .id' "$FILE_NAME" --arg CONTENT_ID "$CONTENT_ID")
           echo '::set-output name=item_title::'$(jq -r '.data.organization.projectV2.items.nodes[] | select(.content.id==$CONTENT_ID) | .content.title' "$FILE_NAME" --arg CONTENT_ID "$CONTENT_ID")
           echo '::set-output name=field_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' "$FILE_NAME" --arg FIELD "$FIELD")
-          echo '::set-output name=field_is_select::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | has("options")' "$FILE_NAME" --arg FIELD "$FIELD")
+          echo '::set-output name=field_type::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType |= ascii_downcase' "$FILE_NAME" --arg FIELD "$FIELD")
           echo '::set-output name=option_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name | contains($VALUE)) | .id' "$FILE_NAME" --arg VALUE "$VALUE" --arg FIELD "$FIELD")
 
     - name: Ensure project, item, field, and option were found
@@ -127,7 +124,7 @@ runs:
         PROJECT_ID: ${{ steps.parse_project_metadata.outputs.project_id }}
         ITEM_ID: ${{ steps.parse_project_metadata.outputs.item_id }}
         FIELD_ID: ${{ steps.parse_project_metadata.outputs.field_id }}
-        FIELD_IS_SELECT: ${{ steps.parse_project_metadata.outputs.field_is_select }}
+        FIELD_TYPE: ${{ steps.parse_project_metadata.outputs.field_type }}
         OPTION_ID: ${{ steps.parse_project_metadata.outputs.option_id }}
       shell: bash
       run: |
@@ -135,28 +132,28 @@ runs:
         if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then echo "Project '$PROJECT_NUMBER' not found for organization '$ORGANIZATION'"; exit 1; fi
         if [ -z "$ITEM_ID" ]; then echo "Item not found with ID '$CONTENT_ID'"; exit 1; fi
         if [ -z "$FIELD_ID" ]; then echo "Field '$FIELD' not found"; exit 1; fi
-        if [[ "$FIELD_IS_SELECT" = "true" && -z "$OPTION_ID" ]]; then echo "Option not found with value '$VALUE'"; exit 1; fi
+        if [[ "$FIELD_TYPE" = "single_select" && -z "$OPTION_ID" ]]; then echo "Option not found with value '$VALUE'"; exit 1; fi
     
     - name: Parse value
       shell: bash
       id: parse_value
       env:
-        FIELD_IS_SELECT: ${{ steps.parse_project_metadata.outputs.field_is_select }}
+        FIELD_TYPE: ${{ steps.parse_project_metadata.outputs.field_type }}
         OPTION_ID: ${{ steps.parse_project_metadata.outputs.option_id }}
         VALUE: ${{ inputs.value }}
       run: |
         # Parse value
-        if [ "$FIELD_IS_SELECT" = "true" ]; then
+        if [ "$FIELD_TYPE" = "single_select" ]; then
           echo "::set-output name=value_to_set::$OPTION_ID"
           echo '::set-output name=value_type::singleSelectOptionId'
           echo '::set-output name=value_graphql_type::String'
         else
           echo "::set-output name=value_to_set::$VALUE"
-          echo '::set-output name=value_type::'${{ inputs.value_type }}
+          echo "::set-output name=value_type::$FIELD_TYPE"
 
-          if [ "${{ inputs.value_type }}" = "date" ]; then
+          if [ "$FIELD_TYPE" = "date" ]; then
             echo '::set-output name=value_graphql_type::Date'
-          elif [ "${{ inputs.value_type }}" = "number" ]; then
+          elif [ "$FIELD_TYPE" = "number" ]; then
             echo '::set-output name=value_graphql_type::Float'
           else
             echo '::set-output name=value_graphql_type::String'

--- a/action.yml
+++ b/action.yml
@@ -149,9 +149,18 @@ runs:
         if [ "$FIELD_IS_SELECT" = "true" ]; then
           echo "::set-output name=value_to_set::$OPTION_ID"
           echo '::set-output name=value_type::singleSelectOptionId'
+          echo '::set-output name=value_graphql_type::String'
         else
           echo "::set-output name=value_to_set::$VALUE"
           echo '::set-output name=value_type::'${{ inputs.value_type }}
+
+          if [ "${{ inputs.value_type }}" = "date" ]
+            echo '::set-output name=value_graphql_type::Date'
+          elsif [ "${{ inputs.value_type }}" = "number" ]
+            echo '::set-output name=value_graphql_type::Float'
+          else
+            echo '::set-output name=value_graphql_type::String'
+          fi
         fi
 
     - name: Update field
@@ -165,7 +174,7 @@ runs:
         VALUE_TO_SET: ${{ steps.parse_value.outputs.value_to_set }}
         VALUE: ${{ inputs.value }}
         QUERY: |
-          mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
+          mutation($project: ID!, $item: ID!, $field: ID!, $value: ${{ steps.parse_value.outputs.value_graphql_type }}) {
             updateProjectV2ItemFieldValue(
               input: {
                 projectId: $project

--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,10 @@ runs:
     - name: Parse field type
       shell: bash
       id: parse_field_type
+      env:
+        FIELD_IS_SELECT: ${{ steps.parse_project_metadata.outputs.field_is_select }}
+        OPTION_ID: ${{ steps.parse_project_metadata.outputs.option_id }}
+        VALUE: ${{ inputs.value }}
       run: |
         # Parse field type
         if [ "$FIELD_IS_SELECT" = "true" ]; then
@@ -150,12 +154,9 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         FIELD: ${{ inputs.field }}
-        VALUE: ${{ inputs.value }}
         PROJECT_ID: ${{ steps.parse_project_metadata.outputs.project_id }}
         ITEM_ID: ${{ steps.parse_project_metadata.outputs.item_id }}
         FIELD_ID: ${{ steps.parse_project_metadata.outputs.field_id }}
-        FIELD_IS_SELECT: ${{ steps.parse_project_metadata.outputs.field_is_select }}
-        OPTION_ID: ${{ steps.parse_project_metadata.outputs.option_id }}
         ITEM_TITLE: ${{ steps.parse_project_metadata.outputs.item_title }}
         VALUE_TO_SET: ${{ steps.parse_field_type.outputs.value_to_set }}
         QUERY: |

--- a/action.yml
+++ b/action.yml
@@ -146,18 +146,18 @@ runs:
         if [ "$FIELD_TYPE" = "single_select" ]; then
           echo "::set-output name=value_to_set::$OPTION_ID"
           echo '::set-output name=value_type::singleSelectOptionId'
-          echo '::set-output name=value_graphql_type::String'
         else
           echo "::set-output name=value_to_set::$VALUE"
           echo "::set-output name=value_type::$FIELD_TYPE"
+        fi
 
-          if [ "$FIELD_TYPE" = "date" ]; then
-            echo '::set-output name=value_graphql_type::Date'
-          elif [ "$FIELD_TYPE" = "number" ]; then
-            echo '::set-output name=value_graphql_type::Float'
-          else
-            echo '::set-output name=value_graphql_type::String'
-          fi
+        # Set GraphQL Field Type
+        if [ "$FIELD_TYPE" = "date" ]; then
+          echo '::set-output name=value_graphql_type::Date'
+        elif [ "$FIELD_TYPE" = "number" ]; then
+          echo '::set-output name=value_graphql_type::Float'
+        else
+          echo '::set-output name=value_graphql_type::String'
         fi
 
     - name: Update field

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
   github_token:
     description: A GitHub Token with access to both the source issue and the destination project (`repo` and `write:org` scopes)
     required: true
+  value_type:
+    description: The type of value to update (text, date, number, iterationId, or singleSectionOptionId). See https://docs.github.com/en/graphql/reference/input-objects#projectv2fieldvalue.
+    required: false
+    default: text
 outputs:
   project_id:
     description: "The global ID of the project"
@@ -147,7 +151,7 @@ runs:
           echo '::set-output name=field_type::singleSelectOptionId'
         else
           echo "::set-output name=value_to_set::$VALUE"
-          echo '::set-output name=field_type::text'
+          echo '::set-output name=field_type::'${{ inputs.value_type }}
         fi
 
     - name: Update field

--- a/action.yml
+++ b/action.yml
@@ -145,7 +145,7 @@ runs:
         OPTION_ID: ${{ steps.parse_project_metadata.outputs.option_id }}
         ITEM_TITLE: ${{ steps.parse_project_metadata.outputs.item_title }}
         QUERY: |
-          mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
+          mutation($project: ID!, $item: ID!, $field: ID!, $value: ProjectV2FieldValue!) {
             updateProjectV2ItemFieldValue(
               input: {
                 projectId: $project

--- a/action.yml
+++ b/action.yml
@@ -164,9 +164,9 @@ runs:
       run: |
         # Update field
         if [ "$FIELD_IS_SELECT" = "true" ]; then
-          export VALUE_TO_SET="$OPTION_ID"
+          export VALUE_TO_SET="$(jq -r '{"singleSelectOptionId": $OPTION_ID}' -n '{}' --arg OPTION_ID "$OPTION_ID")"
         else
-          export VALUE_TO_SET="$VALUE"
+          export VALUE_TO_SET="$(jq -r '{"text": $VALUE}' -n '{}' --arg VALUE "$VALUE")"
         fi
 
         gh api graphql -f query="$QUERY" -f project=$PROJECT_ID -f item=$ITEM_ID -f field=$FIELD_ID -f value="$VALUE_TO_SET"

--- a/action.yml
+++ b/action.yml
@@ -137,21 +137,21 @@ runs:
         if [ -z "$FIELD_ID" ]; then echo "Field '$FIELD' not found"; exit 1; fi
         if [[ "$FIELD_IS_SELECT" = "true" && -z "$OPTION_ID" ]]; then echo "Option not found with value '$VALUE'"; exit 1; fi
     
-    - name: Parse field type
+    - name: Parse value
       shell: bash
-      id: parse_field_type
+      id: parse_value
       env:
         FIELD_IS_SELECT: ${{ steps.parse_project_metadata.outputs.field_is_select }}
         OPTION_ID: ${{ steps.parse_project_metadata.outputs.option_id }}
         VALUE: ${{ inputs.value }}
       run: |
-        # Parse field type
+        # Parse value
         if [ "$FIELD_IS_SELECT" = "true" ]; then
           echo "::set-output name=value_to_set::$OPTION_ID"
-          echo '::set-output name=field_type::singleSelectOptionId'
+          echo '::set-output name=value_type::singleSelectOptionId'
         else
           echo "::set-output name=value_to_set::$VALUE"
-          echo '::set-output name=field_type::'${{ inputs.value_type }}
+          echo '::set-output name=value_type::'${{ inputs.value_type }}
         fi
 
     - name: Update field
@@ -162,7 +162,7 @@ runs:
         ITEM_ID: ${{ steps.parse_project_metadata.outputs.item_id }}
         FIELD_ID: ${{ steps.parse_project_metadata.outputs.field_id }}
         ITEM_TITLE: ${{ steps.parse_project_metadata.outputs.item_title }}
-        VALUE_TO_SET: ${{ steps.parse_field_type.outputs.value_to_set }}
+        VALUE_TO_SET: ${{ steps.parse_value.outputs.value_to_set }}
         VALUE: ${{ inputs.value }}
         QUERY: |
           mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
@@ -172,7 +172,7 @@ runs:
                 itemId: $item
                 fieldId: $field
                 value: {
-                  ${{ steps.parse_field_type.outputs.field_type }}: $value
+                  ${{ steps.parse_value.outputs.value_type }}: $value
                 }
               }
             ) {

--- a/action.yml
+++ b/action.yml
@@ -139,10 +139,10 @@ runs:
       run: |
         # Parse field type
         if [ "$FIELD_IS_SELECT" = "true" ]; then
-          echo '::set-output name=value_to_set::"$OPTION_ID"'
+          echo "::set-output name=value_to_set::$OPTION_ID"
           echo '::set-output name=field_type::singleSelectOptionId'
         else
-          echo '::set-output name=value_to_set::"$VALUE"'
+          echo "::set-output name=value_to_set::$VALUE"
           echo '::set-output name=field_type::text'
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -132,6 +132,18 @@ runs:
         if [ -z "$ITEM_ID" ]; then echo "Item not found with ID '$CONTENT_ID'"; exit 1; fi
         if [ -z "$FIELD_ID" ]; then echo "Field '$FIELD' not found"; exit 1; fi
         if [[ "$FIELD_IS_SELECT" = "true" && -z "$OPTION_ID" ]]; then echo "Option not found with value '$VALUE'"; exit 1; fi
+    
+    - name: Parse field type
+      shell: bash
+      id: parse_field_type
+      run: |
+        if [ "$FIELD_IS_SELECT" = "true" ]; then
+          export VALUE_TO_SET="$OPTION_ID"
+          echo '::set-output name=field_type::singleSelectOptionId'
+        else
+          export VALUE_TO_SET="$VALUE"
+          echo '::set-output name=field_type::text'
+        fi
 
     - name: Update field
       env:
@@ -145,13 +157,15 @@ runs:
         OPTION_ID: ${{ steps.parse_project_metadata.outputs.option_id }}
         ITEM_TITLE: ${{ steps.parse_project_metadata.outputs.item_title }}
         QUERY: |
-          mutation($project: ID!, $item: ID!, $field: ID!, $value: ProjectV2FieldValue!) {
+          mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
             updateProjectV2ItemFieldValue(
               input: {
                 projectId: $project
                 itemId: $item
                 fieldId: $field
-                value: $value
+                value: {
+                  ${{ steps.parse_field_type.outputs.field_type }}: $value
+                }
               }
             ) {
               projectV2Item {
@@ -162,13 +176,6 @@ runs:
 
       shell: bash
       run: |
-        # Update field
-        if [ "$FIELD_IS_SELECT" = "true" ]; then
-          export VALUE_TO_SET="$(jq -r '{"singleSelectOptionId": $OPTION_ID}' -n '{}' --arg OPTION_ID "$OPTION_ID")"
-        else
-          export VALUE_TO_SET="$(jq -r '{"text": $VALUE}' -n '{}' --arg VALUE "$VALUE")"
-        fi
-
         gh api graphql -f query="$QUERY" -F project=$PROJECT_ID -F item=$ITEM_ID -F field=$FIELD_ID -F value="$VALUE_TO_SET"
 
         echo ""

--- a/action.yml
+++ b/action.yml
@@ -137,11 +137,12 @@ runs:
       shell: bash
       id: parse_field_type
       run: |
+        # Parse field type
         if [ "$FIELD_IS_SELECT" = "true" ]; then
-          export VALUE_TO_SET="$OPTION_ID"
+          echo '::set-output name=value_to_set::"$OPTION_ID"'
           echo '::set-output name=field_type::singleSelectOptionId'
         else
-          export VALUE_TO_SET="$VALUE"
+          echo '::set-output name=value_to_set::"$VALUE"'
           echo '::set-output name=field_type::text'
         fi
 
@@ -156,6 +157,7 @@ runs:
         FIELD_IS_SELECT: ${{ steps.parse_project_metadata.outputs.field_is_select }}
         OPTION_ID: ${{ steps.parse_project_metadata.outputs.option_id }}
         ITEM_TITLE: ${{ steps.parse_project_metadata.outputs.item_title }}
+        VALUE_TO_SET: ${{ steps.parse_field_type.outputs.value_to_set }}
         QUERY: |
           mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
             updateProjectV2ItemFieldValue(
@@ -176,6 +178,7 @@ runs:
 
       shell: bash
       run: |
+        # Update project
         gh api graphql -f query="$QUERY" -F project=$PROJECT_ID -F item=$ITEM_ID -F field=$FIELD_ID -F value="$VALUE_TO_SET"
 
         echo ""

--- a/action.yml
+++ b/action.yml
@@ -156,7 +156,7 @@ runs:
 
           if [ "${{ inputs.value_type }}" = "date" ]
             echo '::set-output name=value_graphql_type::Date'
-          elsif [ "${{ inputs.value_type }}" = "number" ]
+          elif [ "${{ inputs.value_type }}" = "number" ]
             echo '::set-output name=value_graphql_type::Float'
           else
             echo '::set-output name=value_graphql_type::String'

--- a/action.yml
+++ b/action.yml
@@ -110,8 +110,8 @@ runs:
           echo '::set-output name=item_id::'$(jq -r '.data.organization.projectV2.items.nodes[] | select(.content.id==$CONTENT_ID) | .id' "$FILE_NAME" --arg CONTENT_ID "$CONTENT_ID")
           echo '::set-output name=item_title::'$(jq -r '.data.organization.projectV2.items.nodes[] | select(.content.id==$CONTENT_ID) | .content.title' "$FILE_NAME" --arg CONTENT_ID "$CONTENT_ID")
           echo '::set-output name=field_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' "$FILE_NAME" --arg FIELD "$FIELD")
-          echo '::set-output name=field_is_select::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .settings | fromjson | has("options")' "$FILE_NAME" --arg FIELD "$FIELD")
-          echo '::set-output name=option_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .settings | fromjson | .options[]? | select(.name | contains($VALUE)) | .id' "$FILE_NAME" --arg VALUE "$VALUE" --arg FIELD "$FIELD")
+          echo '::set-output name=field_is_select::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | has("options")' "$FILE_NAME" --arg FIELD "$FIELD")
+          echo '::set-output name=option_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name | contains($VALUE)) | .id' "$FILE_NAME" --arg VALUE "$VALUE" --arg FIELD "$FIELD")
 
     - name: Ensure project, item, field, and option were found
       env:


### PR DESCRIPTION
[GitHub recently announced a breaking change to the Projects API](https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/). `projectNext` will now be `projectV2`, in addition to changes to how field values are passed in the mutation. This PR updates the action to use the new non-preview GraphQL Schema.

One challenge, is that the `value` field of the mutation must now be passed as a hash, with a different key depending on the field type. This is especially challenging because (A) GraphQL keys cannot be variables, and (B) the GitHub API does not accept hash variables. To get around this, I used Actions variable interpolation to modify the GraphQL query (key and variable type) to the appropriate field type and graphql variable type prior to passing the GraphQL query string to the `gh api` command. This metadata is pulled from the project object, so it should be a transparent and non-breaking change for existing implementations.

You can see a successful run for multiple types of fields [here](https://github.com/balter-test-org/update-project-action-integration-test/runs/7080083770?check_suite_focus=true).