### PR TITLE
Support all types of field values, including all-digit single-select IDs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -263,6 +263,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         FIELD: ${{ inputs.field }}
+        FIELD_TYPE: ${{ steps.parse_project_fields_metadata.outputs.field_type }}
         PROJECT_ID: ${{ steps.parse_project_fields_metadata.outputs.project_id }}
         ITEM_ID: ${{ steps.parse_content_metadata.outputs.item_id }}
         FIELD_ID: ${{ steps.parse_project_fields_metadata.outputs.field_id }}
@@ -289,7 +290,16 @@ runs:
       shell: bash
       run: |
         # Update project
-        gh api graphql -f query="$QUERY" -F project="$PROJECT_ID" -F item="$ITEM_ID" -F field="$FIELD_ID" -F value="$VALUE_TO_SET"
+        if [ "$FIELD_TYPE" = "single_select" ]; then
+          # From https://cli.github.com/manual/gh_api:
+          # > The -F/--field flag has magic type conversion based on the format of the value:
+          # >   literal values "true", "false", "null", and integer numbers get converted to appropriate JSON types;
+          # Single select option ids are hexadecimal values, but if they are all digits, gh cli coerces them to integers
+          # Reading a value from stdin bypasses the conversion:
+          echo -n $VALUE_TO_SET | gh api graphql -f query="$QUERY" -F project="$PROJECT_ID" -F item="$ITEM_ID" -F field="$FIELD_ID" -F value="@-"
+        else
+          gh api graphql -f query="$QUERY" -F project="$PROJECT_ID" -F item="$ITEM_ID" -F field="$FIELD_ID" -F value="$VALUE_TO_SET"
+        fi
 
         echo ""
         echo "Updated field '$FIELD' on '$ITEM_TITLE' to '$VALUE'. Happy reporting! 📈"


### PR DESCRIPTION
**Problem**

A single select option id is an 8-character hexadecimal value (e.g. `47fc9ee4`).
There's a 2.3% chance that this id will be comprised only of digits (e.g. `12345678`): (10/16)^8 = 0.0232
If an option id is comprised of digits only, this action cannot set the field to this value.

**Investigation Results**

The underlying `gh api graphql` field update call is doing an automatic conversion of values that look like integers ([source](https://cli.github.com/manual/gh_api)):
> The -F/--field flag has magic type conversion based on the format of the value:
> - literal values "true", "false", "null", and **integer numbers** get converted to appropriate JSON types;

It leads to this kind of error (`98236657` in the example is an option ID (`VALUE_TO_SET`) passed in as `-F value="$VALUE_TO_SET"`:
```
gh: Variable $value of type String was provided invalid value
```

```json
{
  "errors": [
    {
      "extensions": {
        "value": 98236657,
        "problems": [
          {
            "path": [],
            "explanation": "Could not coerce value 98236657 to String"
          }
        ]
      },
      "locations": [
        {
          "line": 1,
          "column": 50
        }
      ],
      "message": "Variable $value of type String was provided invalid value"
    }
  ]
}
```

**Solution**

Switching from direct value passing to reading the value from `stdin` since it bypasses the conversion and treats the passed value as a string.