### PR TITLE
Update the action to use the new output format

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -135,15 +135,9 @@ runs:
           item_id=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")
           item_title=$(jq -r '.data.node.title' "$FILE_NAME")
           item_value=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).field.value' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")
-          echo item_id $item_id
-          echo item_title $item_title
-          echo item_value $item_value
-          echo ""
           echo "item_id=$item_id" >> $GITHUB_OUTPUT
           echo "item_title=$item_title" >> $GITHUB_OUTPUT
           echo "item_value=$item_value" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
-
     - name: Ensure content item was found
       env:
         CONTENT_ID: ${{ inputs.content_id }}
@@ -203,10 +197,14 @@ runs:
         FILE_NAME: ${{ steps.fetch_project_fields_metadata.outputs.file_name }}
       run: |
           # Parse project metadata
-          echo "project_id='$(jq -r '.data.organization.projectV2.id' ""$FILE_NAME""")"  >> $GITHUB_OUTPUT
-          echo "field_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' ""$FILE_NAME"" --arg FIELD ""$FIELD""")"  >> $GITHUB_OUTPUT
-          echo "field_type='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType | ascii_downcase' ""$FILE_NAME"" --arg FIELD ""$FIELD"")"  >> $GITHUB_OUTPUT
-          echo "option_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name == $VALUE) | .id' ""$FILE_NAME"" --arg VALUE ""$VALUE"" --arg FIELD ""$FIELD"")"  >> $GITHUB_OUTPUT
+          project_id=$(jq -r '.data.organization.projectV2.id' "$FILE_NAME")
+          field_id=$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' "$FILE_NAME" --arg FIELD "$FIELD")
+          field_type=$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType | ascii_downcase' "$FILE_NAME" --arg FIELD "$FIELD")
+          option_id=$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name == $VALUE) | .id' "$FILE_NAME" --arg VALUE "$VALUE" --arg FIELD "$FIELD")
+          echo "project_id=$project_id" >> $GITHUB_OUTPUT
+          echo "field_id=$field_id" >> $GITHUB_OUTPUT
+          echo "field_type=$field_type" >> $GITHUB_OUTPUT
+          echo "option_id=$option_id"  >> $GITHUB_OUTPUT
 
     - name: Ensure project, field, and option were found
       env:

--- a/action.yml
+++ b/action.yml
@@ -133,9 +133,12 @@ runs:
         FILE_NAME: ${{ steps.fetch_content_metadata.outputs.file_name }}
       run: |
           # Parse content metadata
-          echo "name=item_id='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' ""$FILE_NAME"" --arg OWNER ""$OWNER"" --arg PROJECT_NUMBER ""$PROJECT_NUMBER"")'" >> $GITHUB_OUTPUT
-          echo "name=item_title='$(jq -r '.data.node.title' ""$FILE_NAME"")'" >> $GITHUB_OUTPUT
-          echo "name=item_value='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).field.value' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")'" >> $GITHUB_OUTPUT
+          item_id=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' ""$FILE_NAME"" --arg OWNER ""$OWNER"" --arg PROJECT_NUMBER ""$PROJECT_NUMBER"")
+          item_title=$(jq -r '.data.node.title' ""$FILE_NAME"")
+          item_value=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).field.value' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")
+          echo "name=item_id='$item_id'" >> $GITHUB_OUTPUT
+          echo "name=item_title='$item_title'" >> $GITHUB_OUTPUT
+          echo "name=item_value='$item_value'" >> $GITHUB_OUTPUT
 
     - name: Ensure content item was found
       env:

--- a/action.yml
+++ b/action.yml
@@ -133,8 +133,8 @@ runs:
         FILE_NAME: ${{ steps.fetch_content_metadata.outputs.file_name }}
       run: |
           # Parse content metadata
-          echo 'name=item_id='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER") >> $GITHUB_OUTPUT
-          echo 'name=item_title='$(jq -r '.data.node.title' "$FILE_NAME") >> $GITHUB_OUTPUT
+          echo "name=item_id='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' ""$FILE_NAME"" --arg OWNER ""$OWNER"" --arg PROJECT_NUMBER ""$PROJECT_NUMBER"")" >> $GITHUB_OUTPUT
+          echo "name=item_title='$(jq -r '.data.node.title' ""$FILE_NAME"")" >> $GITHUB_OUTPUT
           echo 'name=item_value='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).field.value' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER") >> $GITHUB_OUTPUT
 
     - name: Ensure content item was found
@@ -196,10 +196,10 @@ runs:
         FILE_NAME: ${{ steps.fetch_project_fields_metadata.outputs.file_name }}
       run: |
           # Parse project metadata
-          echo 'name=project_id='$(jq -r '.data.organization.projectV2.id' "$FILE_NAME")
-          echo 'name=field_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' "$FILE_NAME" --arg FIELD "$FIELD")
-          echo 'name=field_type='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType | ascii_downcase' "$FILE_NAME" --arg FIELD "$FIELD")
-          echo 'name=option_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name == $VALUE) | .id' "$FILE_NAME" --arg VALUE "$VALUE" --arg FIELD "$FIELD")
+          echo "name=project_id='$(jq -r '.data.organization.projectV2.id' ""$FILE_NAME""")"  >> $GITHUB_OUTPUT
+          echo "name=field_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' ""$FILE_NAME"" --arg FIELD ""$FIELD""")"  >> $GITHUB_OUTPUT
+          echo "name=field_type='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType | ascii_downcase' ""$FILE_NAME"" --arg FIELD ""$FIELD"")"  >> $GITHUB_OUTPUT
+          echo "name=option_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name == $VALUE) | .id' ""$FILE_NAME"" --arg VALUE ""$VALUE"" --arg FIELD ""$FIELD"")"  >> $GITHUB_OUTPUT
 
     - name: Ensure project, field, and option were found
       env:

--- a/action.yml
+++ b/action.yml
@@ -115,13 +115,13 @@ runs:
           }
       shell: bash
       run: |
-        set -ex
         # Fetch project fields metadata
         if [ ! -f "$FILE_NAME" ] || [ "$OPERATION" == "read" ]; then
           gh api graphql -f query="$QUERY" -F issue_id="$CONTENT_ID" -F field_name="$FIELD_NAME" > "$FILE_NAME"
         else
           echo "Using cached project fields metadata from '$FILE_NAME'"
         fi
+        echo "file_name=$FILE_NAME" >> $GITHUB_OUTPUT
 
     - name: Parse content ID, value and title
       id: parse_content_metadata
@@ -129,7 +129,7 @@ runs:
       env:
         PROJECT_NUMBER: ${{ inputs.project_number }}
         OWNER: ${{ inputs.organization }}
-        FILE_NAME: organization-${{ inputs.organization }}-issue-${{ inputs.content_id }}.json
+        FILE_NAME: ${{ steps.fetch_content_metadata.outputs.file_name }}
       run: |
           # Parse content metadata
           item_id=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")

--- a/action.yml
+++ b/action.yml
@@ -138,6 +138,7 @@ runs:
           echo item_id $item_id
           echo item_title $item_title
           echo item_value $item_value
+          cat $FILE_NAME
           echo "name=item_id='$item_id'" >> $GITHUB_OUTPUT
           echo "name=item_title='$item_title'" >> $GITHUB_OUTPUT
           echo "name=item_value='$item_value'" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -121,8 +121,9 @@ runs:
         else
           echo "Using cached project fields metadata from '$FILE_NAME'"
         fi
-
+        echo $FILENAME
         echo "name=file_name=$FILE_NAME" >> $GITHUB_OUTPUT
+        cat $GITHUB_OUTPUT
 
     - name: Parse content ID, value and title
       id: parse_content_metadata

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
           echo "Using cached project fields metadata from '$FILE_NAME'"
         fi
 
-        echo "::set-output name=file_name::$FILE_NAME"
+        echo "name=file_name=$FILE_NAME" >> $GITHUB_OUTPUT
 
     - name: Parse content ID, value and title
       id: parse_content_metadata
@@ -133,9 +133,9 @@ runs:
         FILE_NAME: ${{ steps.fetch_content_metadata.outputs.file_name }}
       run: |
           # Parse content metadata
-          echo '::set-output name=item_id::'$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")
-          echo '::set-output name=item_title::'$(jq -r '.data.node.title' "$FILE_NAME")
-          echo '::set-output name=item_value::'$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).field.value' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")
+          echo 'name=item_id='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER") >> $GITHUB_OUTPUT
+          echo 'name=item_title='$(jq -r '.data.node.title' "$FILE_NAME") >> $GITHUB_OUTPUT
+          echo 'name=item_value='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).field.value' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER") >> $GITHUB_OUTPUT
 
     - name: Ensure content item was found
       env:
@@ -185,7 +185,7 @@ runs:
           echo "Using cached project fields metadata from '$FILE_NAME'"
         fi
 
-        echo "::set-output name=file_name::$FILE_NAME"
+        echo "name=file_name=$FILE_NAME" >> $GITHUB_OUTPUT
 
     - name: Parse project fields metadata
       id: parse_project_fields_metadata
@@ -196,10 +196,10 @@ runs:
         FILE_NAME: ${{ steps.fetch_project_fields_metadata.outputs.file_name }}
       run: |
           # Parse project metadata
-          echo '::set-output name=project_id::'$(jq -r '.data.organization.projectV2.id' "$FILE_NAME")
-          echo '::set-output name=field_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' "$FILE_NAME" --arg FIELD "$FIELD")
-          echo '::set-output name=field_type::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType | ascii_downcase' "$FILE_NAME" --arg FIELD "$FIELD")
-          echo '::set-output name=option_id::'$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name == $VALUE) | .id' "$FILE_NAME" --arg VALUE "$VALUE" --arg FIELD "$FIELD")
+          echo 'name=project_id='$(jq -r '.data.organization.projectV2.id' "$FILE_NAME")
+          echo 'name=field_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' "$FILE_NAME" --arg FIELD "$FIELD")
+          echo 'name=field_type='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType | ascii_downcase' "$FILE_NAME" --arg FIELD "$FIELD")
+          echo 'name=option_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name == $VALUE) | .id' "$FILE_NAME" --arg VALUE "$VALUE" --arg FIELD "$FIELD")
 
     - name: Ensure project, field, and option were found
       env:
@@ -230,20 +230,20 @@ runs:
       run: |
         # Parse value
         if [ "$FIELD_TYPE" = "single_select" ]; then
-          echo "::set-output name=value_to_set::$OPTION_ID"
-          echo '::set-output name=value_type::singleSelectOptionId'
+          echo "name=value_to_set=$OPTION_ID" >> $GITHUB_OUTPUT
+          echo 'name=value_type=singleSelectOptionId' >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=value_to_set::$VALUE"
-          echo "::set-output name=value_type::$FIELD_TYPE"
+          echo "name=value_to_set=$VALUE" >> $GITHUB_OUTPUT
+          echo "name=value_type=$FIELD_TYPE" >> $GITHUB_OUTPUT
         fi
 
         # Set GraphQL Field Type
         if [ "$FIELD_TYPE" = "date" ]; then
-          echo '::set-output name=value_graphql_type::Date'
+          echo 'name=value_graphql_type=Date' >> $GITHUB_OUTPUT
         elif [ "$FIELD_TYPE" = "number" ]; then
-          echo '::set-output name=value_graphql_type::Float'
+          echo 'name=value_graphql_type=Float' >> $GITHUB_OUTPUT
         else
-          echo '::set-output name=value_graphql_type::String'
+          echo 'name=value_graphql_type=String' >> $GITHUB_OUTPUT
         fi
 
     - name: Output values
@@ -253,9 +253,9 @@ runs:
         OPERATION: ${{ inputs.operation }}
       run: |
         if [ "$OPERATION" == "read" ]; then
-          echo ''::set-output name=field_updated_value::${{ steps.parse_content_metadata.outputs.item_value }}
+          echo "name=field_updated_value="${{ steps.parse_content_metadata.outputs.item_value }} >> $GITHUB_OUTPUT
         else
-          echo ''::set-output name=field_updated_value::${{ inputs.value }}
+          echo "name=field_updated_value="${{ inputs.value }} >> $GITHUB_OUTPUT
         fi
 
     - name: Update field

--- a/action.yml
+++ b/action.yml
@@ -121,7 +121,7 @@ runs:
           gh api graphql -f query="$QUERY" -F issue_id="$CONTENT_ID" -F field_name="$FIELD_NAME" > "$FILE_NAME"
         else
           echo "Using cached project fields metadata from '$FILE_NAME'"
-        fi"
+        fi
 
     - name: Parse content ID, value and title
       id: parse_content_metadata

--- a/action.yml
+++ b/action.yml
@@ -133,8 +133,8 @@ runs:
         FILE_NAME: ${{ steps.fetch_content_metadata.outputs.file_name }}
       run: |
           # Parse content metadata
-          item_id=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' ""$FILE_NAME"" --arg OWNER ""$OWNER"" --arg PROJECT_NUMBER ""$PROJECT_NUMBER"")
-          item_title=$(jq -r '.data.node.title' ""$FILE_NAME"")
+          item_id=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")
+          item_title=$(jq -r '.data.node.title' "$FILE_NAME")
           item_value=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).field.value' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")
           echo "name=item_id='$item_id'" >> $GITHUB_OUTPUT
           echo "name=item_title='$item_title'" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -115,15 +115,13 @@ runs:
           }
       shell: bash
       run: |
+        set -ex
         # Fetch project fields metadata
         if [ ! -f "$FILE_NAME" ] || [ "$OPERATION" == "read" ]; then
           gh api graphql -f query="$QUERY" -F issue_id="$CONTENT_ID" -F field_name="$FIELD_NAME" > "$FILE_NAME"
         else
           echo "Using cached project fields metadata from '$FILE_NAME'"
         fi
-        echo $FILENAME
-        echo "name=file_name=$FILE_NAME" >> $GITHUB_OUTPUT
-        cat $GITHUB_OUTPUT
 
     - name: Parse content ID, value and title
       id: parse_content_metadata
@@ -131,7 +129,7 @@ runs:
       env:
         PROJECT_NUMBER: ${{ inputs.project_number }}
         OWNER: ${{ inputs.organization }}
-        FILE_NAME: ${{ steps.fetch_content_metadata.outputs.file_name }}
+        FILE_NAME: organization-${{ inputs.organization }}-issue-${{ inputs.content_id }}.json
       run: |
           # Parse content metadata
           item_id=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")

--- a/action.yml
+++ b/action.yml
@@ -138,7 +138,7 @@ runs:
           echo item_id $item_id
           echo item_title $item_title
           echo item_value $item_value
-          cat $FILE_NAME
+          echo ""
           echo "name=item_id=$item_id" >> $GITHUB_OUTPUT
           echo "name=item_title=$item_title" >> $GITHUB_OUTPUT
           echo "name=item_value=$item_value" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -135,6 +135,9 @@ runs:
           item_id=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")
           item_title=$(jq -r '.data.node.title' "$FILE_NAME")
           item_value=$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).field.value' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")
+          echo item_id $item_id
+          echo item_title $item_title
+          echo item_value $item_value
           echo "name=item_id='$item_id'" >> $GITHUB_OUTPUT
           echo "name=item_title='$item_title'" >> $GITHUB_OUTPUT
           echo "name=item_value='$item_value'" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -121,7 +121,7 @@ runs:
           gh api graphql -f query="$QUERY" -F issue_id="$CONTENT_ID" -F field_name="$FIELD_NAME" > "$FILE_NAME"
         else
           echo "Using cached project fields metadata from '$FILE_NAME'"
-        fi
+        fi"
 
     - name: Parse content ID, value and title
       id: parse_content_metadata
@@ -139,9 +139,9 @@ runs:
           echo item_title $item_title
           echo item_value $item_value
           echo ""
-          echo "name=item_id=$item_id" >> $GITHUB_OUTPUT
-          echo "name=item_title=$item_title" >> $GITHUB_OUTPUT
-          echo "name=item_value=$item_value" >> $GITHUB_OUTPUT
+          echo "item_id=$item_id" >> $GITHUB_OUTPUT
+          echo "item_title=$item_title" >> $GITHUB_OUTPUT
+          echo "item_value=$item_value" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
 
     - name: Ensure content item was found
@@ -192,7 +192,7 @@ runs:
           echo "Using cached project fields metadata from '$FILE_NAME'"
         fi
 
-        echo "name=file_name=$FILE_NAME" >> $GITHUB_OUTPUT
+        echo "file_name=$FILE_NAME" >> $GITHUB_OUTPUT
 
     - name: Parse project fields metadata
       id: parse_project_fields_metadata
@@ -203,10 +203,10 @@ runs:
         FILE_NAME: ${{ steps.fetch_project_fields_metadata.outputs.file_name }}
       run: |
           # Parse project metadata
-          echo "name=project_id='$(jq -r '.data.organization.projectV2.id' ""$FILE_NAME""")"  >> $GITHUB_OUTPUT
-          echo "name=field_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' ""$FILE_NAME"" --arg FIELD ""$FIELD""")"  >> $GITHUB_OUTPUT
-          echo "name=field_type='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType | ascii_downcase' ""$FILE_NAME"" --arg FIELD ""$FIELD"")"  >> $GITHUB_OUTPUT
-          echo "name=option_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name == $VALUE) | .id' ""$FILE_NAME"" --arg VALUE ""$VALUE"" --arg FIELD ""$FIELD"")"  >> $GITHUB_OUTPUT
+          echo "project_id='$(jq -r '.data.organization.projectV2.id' ""$FILE_NAME""")"  >> $GITHUB_OUTPUT
+          echo "field_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .id' ""$FILE_NAME"" --arg FIELD ""$FIELD""")"  >> $GITHUB_OUTPUT
+          echo "field_type='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .dataType | ascii_downcase' ""$FILE_NAME"" --arg FIELD ""$FIELD"")"  >> $GITHUB_OUTPUT
+          echo "option_id='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD) | .options[]? | select(.name == $VALUE) | .id' ""$FILE_NAME"" --arg VALUE ""$VALUE"" --arg FIELD ""$FIELD"")"  >> $GITHUB_OUTPUT
 
     - name: Ensure project, field, and option were found
       env:
@@ -237,20 +237,20 @@ runs:
       run: |
         # Parse value
         if [ "$FIELD_TYPE" = "single_select" ]; then
-          echo "name=value_to_set=$OPTION_ID" >> $GITHUB_OUTPUT
-          echo 'name=value_type=singleSelectOptionId' >> $GITHUB_OUTPUT
+          echo "value_to_set=$OPTION_ID" >> $GITHUB_OUTPUT
+          echo 'value_type=singleSelectOptionId' >> $GITHUB_OUTPUT
         else
-          echo "name=value_to_set=$VALUE" >> $GITHUB_OUTPUT
-          echo "name=value_type=$FIELD_TYPE" >> $GITHUB_OUTPUT
+          echo "value_to_set=$VALUE" >> $GITHUB_OUTPUT
+          echo "value_type=$FIELD_TYPE" >> $GITHUB_OUTPUT
         fi
 
         # Set GraphQL Field Type
         if [ "$FIELD_TYPE" = "date" ]; then
-          echo 'name=value_graphql_type=Date' >> $GITHUB_OUTPUT
+          echo 'value_graphql_type=Date' >> $GITHUB_OUTPUT
         elif [ "$FIELD_TYPE" = "number" ]; then
-          echo 'name=value_graphql_type=Float' >> $GITHUB_OUTPUT
+          echo 'value_graphql_type=Float' >> $GITHUB_OUTPUT
         else
-          echo 'name=value_graphql_type=String' >> $GITHUB_OUTPUT
+          echo 'value_graphql_type=String' >> $GITHUB_OUTPUT
         fi
 
     - name: Output values
@@ -260,9 +260,9 @@ runs:
         OPERATION: ${{ inputs.operation }}
       run: |
         if [ "$OPERATION" == "read" ]; then
-          echo "name=field_updated_value="${{ steps.parse_content_metadata.outputs.item_value }} >> $GITHUB_OUTPUT
+          echo "field_updated_value="${{ steps.parse_content_metadata.outputs.item_value }} >> $GITHUB_OUTPUT
         else
-          echo "name=field_updated_value="${{ inputs.value }} >> $GITHUB_OUTPUT
+          echo "field_updated_value="${{ inputs.value }} >> $GITHUB_OUTPUT
         fi
 
     - name: Update field

--- a/action.yml
+++ b/action.yml
@@ -139,9 +139,10 @@ runs:
           echo item_title $item_title
           echo item_value $item_value
           cat $FILE_NAME
-          echo "name=item_id='$item_id'" >> $GITHUB_OUTPUT
-          echo "name=item_title='$item_title'" >> $GITHUB_OUTPUT
-          echo "name=item_value='$item_value'" >> $GITHUB_OUTPUT
+          echo "name=item_id=$item_id" >> $GITHUB_OUTPUT
+          echo "name=item_title=$item_title" >> $GITHUB_OUTPUT
+          echo "name=item_value=$item_value" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
 
     - name: Ensure content item was found
       env:

--- a/action.yml
+++ b/action.yml
@@ -133,9 +133,9 @@ runs:
         FILE_NAME: ${{ steps.fetch_content_metadata.outputs.file_name }}
       run: |
           # Parse content metadata
-          echo "name=item_id='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' ""$FILE_NAME"" --arg OWNER ""$OWNER"" --arg PROJECT_NUMBER ""$PROJECT_NUMBER"")" >> $GITHUB_OUTPUT
-          echo "name=item_title='$(jq -r '.data.node.title' ""$FILE_NAME"")" >> $GITHUB_OUTPUT
-          echo 'name=item_value='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).field.value' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER") >> $GITHUB_OUTPUT
+          echo "name=item_id='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).id' ""$FILE_NAME"" --arg OWNER ""$OWNER"" --arg PROJECT_NUMBER ""$PROJECT_NUMBER"")'" >> $GITHUB_OUTPUT
+          echo "name=item_title='$(jq -r '.data.node.title' ""$FILE_NAME"")'" >> $GITHUB_OUTPUT
+          echo "name=item_value='$(jq -r '.data.node.projectItems.nodes | .[] | select(.project.number==($PROJECT_NUMBER|fromjson) and .project.owner.login==$OWNER).field.value' "$FILE_NAME" --arg OWNER "$OWNER" --arg PROJECT_NUMBER "$PROJECT_NUMBER")'" >> $GITHUB_OUTPUT
 
     - name: Ensure content item was found
       env:


### PR DESCRIPTION
As GitHub actions [deprecated set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) I've updated this action to use the new format.