### PR TITLE
Fix input parameter alignment: github_token instead of token

### DIFF
--- a/__test__/main.test.ts
+++ b/__test__/main.test.ts
@@ -77,7 +77,7 @@ describe("with Octokit setup", () => {
     INPUT_VALUE: "testValue",
     INPUT_PROJECT_NUMBER: "1",
     INPUT_OWNER: "github",
-    INPUT_TOKEN: "testToken",
+    INPUT_GITHUB_TOKEN: "testToken",
   };
   let mock: typeof fetchMock;
 

--- a/src/update-project.ts
+++ b/src/update-project.ts
@@ -290,7 +290,7 @@ export function getInputs(): { [key: string]: any } {
  * @param options - Octokit options
  */
 export function setupOctokit(options?: { [key: string]: any }): void {
-  const token = getInput("token", { required: true });
+  const token = getInput("github_token", { required: true });
   octokit = getOctokit(token, options);
 }
 


### PR DESCRIPTION
The action's input parameter is `github_action` (https://github.com/github/update-project-action/blob/main/action.yml#L24) but the TypeScript code is looking for `token`.

This renders the action unusable (passing `github_token` is leading to failure (the code is looking for `token` instead) as well as `token` (unexpected parameter)).