### PR TITLE
operation field must be ommitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ jobs:
           github_token: ${{ secrets.STATUS_UPDATE_TOKEN }}
           organization: github
           project_number: 1234
-          operation: update
           content_id: ${{ github.event.client_payload.command.resource.id }}
           field: Status
           value: ${{ github.event.client_payload.data.status }}
@@ -63,10 +62,10 @@ The Action is largely feature complete with regards to its initial goals. Find a
 * `content_id` - The global ID of the issue or pull request within the project
 * `field` - The field on the project to set the value of
 * `github_token` - A GitHub Token with access to both the source issue and the destination project (`repo` and `write:org` scopes)
-* `operation` - Operation type (update or read)
+* `operation` - Operation type: "read" (omitted for "update" operations)
 * `organization` - The organization that contains the project, defaults to the current repository owner
 * `project_number` - The project number from the project's URL
-* `value` - The value to set the project field to. Only required for operation type update
+* `value` - The value to set the project field to. Only required for update operations
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ jobs:
           github_token: ${{ secrets.STATUS_UPDATE_TOKEN }}
           organization: github
           project_number: 1234
+          operation: update
           content_id: ${{ github.event.client_payload.command.resource.id }}
           field: Status
           value: ${{ github.event.client_payload.data.status }}
@@ -65,7 +66,7 @@ The Action is largely feature complete with regards to its initial goals. Find a
 * `operation` - Operation type (update or read)
 * `organization` - The organization that contains the project, defaults to the current repository owner
 * `project_number` - The project number from the project's URL
-* `value` - The value to set the project field to. Only required for operation type read
+* `value` - The value to set the project field to. Only required for operation type update
 
 ### Outputs
 


### PR DESCRIPTION
Unsure whether the documentation is aspirational or there's another bug, but attempting to update an item yields:

```
Warning: Unexpected input(s) 'operation', valid inputs are ['organization', 'project_number', 'content_id', 'field', 'value', 'github_token']
```

cc @benbalter 